### PR TITLE
Fix endpoint path

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,6 @@
   # openstack dns-api service endpoints (used by users and services)
   default['openstack']['endpoints'][ep_type]['dns-api']['host'] = '127.0.0.1'
   default['openstack']['endpoints'][ep_type]['dns-api']['scheme'] = 'http'
-  default['openstack']['endpoints'][ep_type]['dns-api']['path'] = '/v1/%(tenant_id)s'
   default['openstack']['endpoints'][ep_type]['dns-api']['port'] = 9001
 end
 default['openstack']['bind_service']['all']['dns-api']['host'] = '127.0.0.1'


### PR DESCRIPTION
According to the documentation [1], the endpoint for designate/dns
contains neither a version nor a tenant_id.

[1] https://docs.openstack.org/project-install-guide/dns/ocata/install-ubuntu.html