### PR TITLE
Retry pool update on execute resource failure

### DIFF
--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -157,6 +157,8 @@ execute 'designate-manage pool update' do
   user node['openstack']['dns']['user']
   group node['openstack']['dns']['group']
   command 'designate-manage pool update'
+  retries 3
+  retry_delay 10
   action :nothing
   subscribes :run, 'template[/etc/designate/pools.yaml]'
 end


### PR DESCRIPTION
Running `recipe[openstack-dns::common]` generates the following error:
```text
==> controller: [2017-10-23T05:51:11+00:00] ERROR: Running exception handlers
==> controller: Running handlers complete
==> controller:
==> controller: [2017-10-23T05:51:11+00:00] ERROR: Exception handlers complete
==> controller: Chef Client failed. 406 resources updated in 21 minutes 23 seconds
==> controller: [2017-10-23T05:51:12+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
==> controller: [2017-10-23T05:51:12+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
==> controller: [2017-10-23T05:51:12+00:00] ERROR: execute[designate-manage pool update] (openstack-dns::common line 156) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '1'
==> controller: ---- Begin output of designate-manage pool update ----
==> controller: STDOUT: Updating Pools Configuration
==> controller: ****************************
==> controller: STDERR:
==> controller: ---- End output of designate-manage pool update ----
==> controller: Ran designate-manage pool update returned 1
==> controller: [2017-10-23T05:51:18+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
Chef never successfully completed! Any errors should be visible in the
output above. Please fix your recipes so that they properly complete.
```

Checking the logs for the `designate-manage` CLI:
```text
2017-10-23 07:08:48.948 1069 WARNING oslo_reports.guru_meditation_report [designate-manage - - - - -] Guru meditation now registers SIGUSR1 and SIGUSR2 by default for backward compatibility. SIGUSR1 will no longer be registered in a future release, so please use SIGUSR2 to generate reports.
2017-10-23 07:08:48.957 1069 WARNING oslo_config.cfg [designate-manage - - - - -] Option "rabbit_virtual_host" from group "oslo_messaging_rabbit" is deprecated for removal (Replaced by [DEFAULT]/transport_url).  Its value may be silently ignored in the future.
2017-10-23 07:08:48.959 1069 WARNING oslo_config.cfg [designate-manage - - - - -] Option "rabbit_hosts" from group "oslo_messaging_rabbit" is deprecated for removal (Replaced by [DEFAULT]/transport_url).  Its value may be silently ignored in the future.
2017-10-23 07:08:48.959 1069 WARNING oslo_config.cfg [designate-manage - - - - -] Option "rabbit_userid" from group "oslo_messaging_rabbit" is deprecated for removal (Replaced by [DEFAULT]/transport_url).  Its value may be silently ignored in the future.
2017-10-23 07:08:48.962 1069 WARNING oslo_config.cfg [designate-manage - - - - -] Option "rabbit_password" from group "oslo_messaging_rabbit" is deprecated for removal (Replaced by [DEFAULT]/transport_url).  Its value may be silently ignored in the future.
2017-10-23 07:09:49.378 1069 CRITICAL designate.manage.pool [designate-manage - - - - -] No response received from designate-central. Check it is running, and retry: MessagingTimeout: Timed out waiting for a reply to message ID 2ae2b3f19751437d981723840686c547
```

This PR solves this issue with the `designate-central` not running by adding a `retry` with appropriate timeout on the update pool execute resource.

This issue seems to resolve on the second attempt, giving more time between the time the service is restarted and the pool is updated:
```text
==> controller: Recipe: openstack-dns::common
==> controller:
==> controller: * execute[designate-manage pool update] action run
==> controller:
==> controller:     [execute]
==> controller: Updating Pools Configuration
==> controller:               ****************************
==> controller: [2017-10-23T15:18:27+00:00] INFO: Retrying execution of execute[designate-manage pool update], 2 attempt(s) left
==> controller:     [execute]
==> controller: Updating Pools Configuration
==> controller:
==> controller: ****************************
==> controller:
==> controller: [2017-10-23T15:18:42+00:00] INFO: execute[designate-manage pool update] ran successfully
==> controller:
==> controller: - execute designate-manage pool update
==> controller:
==> controller:
```