### PR TITLE
Fixups for Chef 13 and Pike

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,11 +1,10 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook "openstack-identity",
-  github: "openstack/cookbook-openstack-identity"
-cookbook "openstack-common",
-  github: "openstack/cookbook-openstack-common"
-cookbook "openstackclient",
-  github: "cloudbau/cookbook-openstackclient"
-
+cookbook 'openstack-identity',
+  github: 'openstack/cookbook-openstack-identity'
+cookbook 'openstack-common',
+  github: 'openstack/cookbook-openstack-common'
+cookbook 'openstackclient',
+  github: 'cloudbau/cookbook-openstackclient'

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,176 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,40 +1,39 @@
-task default: ["test"]
+task default: ['test']
 
-task :test => [:lint, :style, :unit]
+task test: [:lint, :style, :unit]
 
-desc "Vendor the cookbooks in the Berksfile"
+desc 'Vendor the cookbooks in the Berksfile'
 task :berks_prep do
-  sh %{chef exec berks vendor}
+  sh %(chef exec berks vendor)
 end
 
-desc "Run FoodCritic (lint) tests"
+desc 'Run FoodCritic (lint) tests'
 task :lint do
-  sh %{chef exec foodcritic --epic-fail any --tags ~FC003 --tags ~FC023 .}
+  sh %(chef exec foodcritic --epic-fail any --tags ~FC003 --tags ~FC023 .)
 end
 
-desc "Run RuboCop (style) tests"
+desc 'Run RuboCop (style) tests'
 task :style do
-  sh %{chef exec rubocop}
+  sh %(chef exec cookstyle)
 end
 
-desc "Run RSpec (unit) tests"
-task :unit => :berks_prep do
-  sh %{chef exec rspec --format documentation}
+desc 'Run RSpec (unit) tests'
+task unit: :berks_prep do
+  sh %(chef exec rspec --format documentation)
 end
 
-desc "Remove the berks-cookbooks directory and the Berksfile.lock"
+desc 'Remove the berks-cookbooks directory and the Berksfile.lock'
 task :clean do
   rm_rf [
     'berks-cookbooks',
-    'Berksfile.lock'
+    'Berksfile.lock',
   ]
 end
 
-desc "All-in-One Neutron build Infra using Common task"
+desc 'All-in-One Neutron build Infra using Common task'
 task :integration do
   # Use the common integration task
   sh %(wget -nv -t 3 -O Rakefile-Common https://raw.githubusercontent.com/openstack/cookbook-openstack-common/master/Rakefile)
   load './Rakefile-Common'
-  Rake::Task["common_integration"].invoke
+  Rake::Task['common_integration'].invoke
 end
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,20 +53,23 @@ case node['platform_family']
 when 'rhel'
   # Note(jh): TBC
   default['openstack']['dns']['platform'] = {
-    'designate_packages' => ['openstack-designate'],
-    'designate_api_service' => 'openstack-designate-api',
-    'designate_central_service' => 'openstack-designate-central',
-    'package_overrides' => ''
+    'designate_packages' => ['openstack-designate-api', 'openstack-designate-central',
+                             'openstack-designate-mdns', 'openstack-designate-producer',
+                             'openstack-designate-worker'],
+    'designate_api_service' => 'designate-api',
+    'designate_central_service' => 'designate-central',
+    'package_overrides' => '',
   }
 when 'debian'
   default['openstack']['dns']['platform'] = {
-    'designate_packages' => ['designate-api', 'designate-central', 'designate-mdns', 'designate-producer', 'designate-worker', 'bind9utils'],
+    'designate_packages' => ['designate-api', 'designate-central', 'designate-mdns',
+                             'designate-producer', 'designate-worker', 'bind9utils'],
     'designate_dashboard_packages' => ['python-designate-dashboard'],
     'designate_api_service' => 'designate-api',
     'designate_central_service' => 'designate-central',
     'designate_mdns_service' => 'designate-mdns',
     'designate_producer_service' => 'designate-producer',
     'designate_worker_service' => 'designate-worker',
-    'package_overrides' => "-o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef'"
+    'package_overrides' => "-o Dpkg::Options::='--force-confold' -o Dpkg::Options::='--force-confdef'",
   }
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,11 @@ maintainer 'cloudbau GmbH'
 maintainer_email 'j.klare@cloudbau.de'
 issues_url 'https://launchpad.net/openstack-chef' if respond_to?(:issues_url)
 source_url 'https://github.com/cloudbau/cookbook-openstack-dns' if respond_to?(:source_url)
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Installs and configures the Designate Service'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.0'
+chef_version '>= 12.5' if respond_to?(:chef_version)
+version '16.0.0'
 
 %w(ubuntu redhat centos).each do |os|
   supports os

--- a/recipes/common.rb
+++ b/recipes/common.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-class ::Chef::Recipe # rubocop:disable Documentation
+class ::Chef::Recipe
   include ::Openstack
 end
 
@@ -67,7 +67,7 @@ end
 db_user = node['openstack']['db']['dns']['username']
 db_pass = get_password 'db', 'designate'
 
-public_identity_endpoint = identity_uri_transform(public_endpoint 'identity')
+public_identity_endpoint = identity_uri_transform(public_endpoint('identity'))
 identity_endpoint = internal_endpoint 'identity'
 
 bind_services = node['openstack']['bind_service']['all']

--- a/recipes/identity_registration.rb
+++ b/recipes/identity_registration.rb
@@ -20,7 +20,7 @@
 
 require 'uri'
 
-class ::Chef::Recipe # rubocop:disable Documentation
+class ::Chef::Recipe
   include ::Openstack
 end
 
@@ -49,7 +49,7 @@ connection_params = {
   openstack_username:     admin_user,
   openstack_api_key:      admin_pass,
   openstack_project_name: admin_project,
-  openstack_domain_name:  admin_domain
+  openstack_domain_name:  admin_domain,
 }
 
 # Register DNS Service
@@ -83,16 +83,10 @@ end
 
 # Register Service User
 openstack_user service_user do
+  role_name service_role
   project_name service_project_name
   domain_name service_domain_name
   password service_pass
   connection_params connection_params
-end
-
-## Grant Service role to Service User for Service Project ##
-openstack_user service_user do
-  role_name service_role
-  project_name service_project_name
-  connection_params connection_params
-  action :grant_role
+  action [:create, :grant_role]
 end


### PR DESCRIPTION
Integration works in Test Kitchen for Ubuntu all the way to InSpec. CentOS fails in an unrelated way in Tempest, but the openstack-dns cookbook appears to perform.